### PR TITLE
Don't restrict symfony/symfony packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,9 +7,8 @@
         "php": "^7.0",
         "doctrine/annotations": "^1.0",
         "phpdocumentor/reflection-docblock": "^3.0|^4.0",
-        "symfony/cache": "^3.3|^4.0",
-        "symfony/property-access": "^3.3|^4.0",
-        "symfony/property-info": "^3.3|^4.0",
-        "symfony/serializer": "^3.3|^4.0"
+        "symfony/property-access": "*",
+        "symfony/property-info": "*",
+        "symfony/serializer": "*"
     }
 }


### PR DESCRIPTION
will allow "unpack" to replace the wildcard by what's in extra.symfony.require also (PR to come)
+ symfony/cache is already a dep of framework-bundle - no need to add it here